### PR TITLE
Fix to work with Meteor 1.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ before_install:
   - "curl -L http://git.io/ejPSng | /bin/sh"
 env:
   - TEST_COMMAND=meteor
+  - TEST_COMMAND=mrt METEOR_RELEASE=1.0.3

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 wrapAsync = (Meteor.wrapAsync)? Meteor.wrapAsync : Meteor._wrapAsync;
 Mongo.Collection.prototype.aggregate = function(pipelines) {
-  var coll = this._getCollection();
+  var coll = MongoInternals.defaultRemoteCollectionDriver().mongo.db.collection(this._name);
   return wrapAsync(coll.aggregate.bind(coll))(pipelines);
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 wrapAsync = (Meteor.wrapAsync)? Meteor.wrapAsync : Meteor._wrapAsync;
 Mongo.Collection.prototype.aggregate = function(pipelines) {
-  var coll = MongoInternals.defaultRemoteCollectionDriver().mongo.db.collection(this._name);
+  var coll;
+  if (undefined !== this.rawCollection) {
+    // >= Meteor 1.0.4
+    coll = this.rawCollection();
+  } else {
+	// < Meteor 1.0.4
+    coll = this._getCollection();
+  }
   return wrapAsync(coll.aggregate.bind(coll))(pipelines);
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 wrapAsync = (Meteor.wrapAsync)? Meteor.wrapAsync : Meteor._wrapAsync;
 Mongo.Collection.prototype.aggregate = function(pipelines) {
   var coll;
-  if (undefined !== this.rawCollection) {
+  if (this.rawCollection) {
     // >= Meteor 1.0.4
     coll = this.rawCollection();
   } else {


### PR DESCRIPTION
There were some Mongo updates mentioned in the Meteor 1.0.4 announcement
@ http://goo.gl/YwsbES I'm thinking were related.  Accessing internals
is hackish and makes sense it broke?

See GitHub issue @ https://github.com/meteorhacks/meteor-aggregate/issues/12